### PR TITLE
Add tests and page objects for products pages

### DIFF
--- a/cypress/e2e/menu.cy.js
+++ b/cypress/e2e/menu.cy.js
@@ -2,28 +2,32 @@
 
 import MenuPage from "../pageobjects/MenuPage";
 import LoginPage from "../pageobjects/LoginPage";
+import ProductsPage from "../pageobjects/ProductsPage";
 
 describe('Menu', () => {
     beforeEach(() => {
+        cy.visit("https://www.saucedemo.com")
+        LoginPage.logIn("standard_user", "secret_sauce")
+        ProductsPage.page.should('be.visible');
         MenuPage.open();
     });
 
-    it('should be able to open the products page', () => {
+    it('open the products page', () => {
         MenuPage.openProductsPage();
-        // TODO Products Page should be.visible
+        ProductsPage.page.should('be.visible');
     });
 
-    it('should be able to open the about page', () => {
+    it('open the about page', () => {
       MenuPage.openAboutPage();
       // TODO check the expected page
     });
 
-    it('should be able to log out', () => {
+    it('log out', () => {
         MenuPage.logout();
         LoginPage.page.should('be.visible');
     });
 
-    it('should be able to clear the cart', () => {
+    it('clear the cart', () => {
         MenuPage.resetAppState();
         // TODO check the state
     });

--- a/cypress/e2e/products.cy.js
+++ b/cypress/e2e/products.cy.js
@@ -1,0 +1,62 @@
+/// <reference types="cypress" />
+
+import LoginPage from "../pageobjects/LoginPage";
+import ProductsPage from "../pageobjects/ProductsPage";
+import ProductDetailsPage from "../pageobjects/ProductDetailsPage";
+import HeaderPage from "../pageobjects/HeaderPage";
+import CartSummaryPage from "../pageobjects/CartSummaryPage";
+
+describe('Products page', () => {
+
+    beforeEach(() => {
+        cy.intercept("POST","https://events.backtrace.io/**", {
+            body: undefined
+        })
+
+        cy.intercept("OPTIONS","https://events.backtrace.io/**", {
+            body: undefined
+        })
+
+        cy.intercept('/service-workers.js', {
+            body: undefined
+        })
+
+        cy.visit("https://www.saucedemo.com")
+        LoginPage.logIn("standard_user", "secret_sauce")
+        ProductsPage.page.should('be.visible');
+    })
+
+    it('all products displayed with expected state', () => {
+        ProductsPage.productList.should('have.length', 6);
+        ProductsPage.addButton.should('be.visible').should('have.length', 6);
+        ProductsPage.removeButton.should('not.exist');
+    });
+
+    it('product details can be opened', () => {
+        ProductsPage.openProductDetails('Sauce Labs Bike Light');
+        ProductDetailsPage.page.should('be.visible');
+        ProductDetailsPage.page.contains('Sauce Labs Bike Light')
+    })
+
+    it('add a product to the cart', () => {
+        HeaderPage.cart.should('have.text', '');
+        ProductsPage.addToCart('Sauce Labs Backpack');
+        HeaderPage.cart.should('have.text', '1');
+        ProductsPage.addButton.should('be.visible').should('have.length', 5);
+        ProductsPage.removeButton.should('be.visible').should('have.length', 1);
+    })
+
+    it('remove a product from the cart', () => {
+        ProductsPage.addToCart('Sauce Labs Backpack');
+        HeaderPage.cart.should('have.text', '1');
+        ProductsPage.removeFromCart('Sauce Labs Backpack')
+        HeaderPage.cart.should('have.text', '');
+        ProductsPage.addButton.should('be.visible').should('have.length', 6);
+        ProductsPage.removeButton.should('not.exist')
+    })
+
+    it('open the cart summary page', () => {
+        HeaderPage.openCart();
+        CartSummaryPage.page.should('be.visible');
+    })
+})

--- a/cypress/pageobjects/CartSummaryPage.js
+++ b/cypress/pageobjects/CartSummaryPage.js
@@ -1,0 +1,10 @@
+class CartSummaryPage {
+
+    // Properties
+
+    get page() {
+        return cy.get('#cart_contents_container');
+    }
+}
+
+export default new CartSummaryPage();

--- a/cypress/pageobjects/HeaderPage.js
+++ b/cypress/pageobjects/HeaderPage.js
@@ -1,5 +1,9 @@
 class HeaderPage {
 
+    get page() {
+        return cy.get('#header_container');
+    }
+
     get cart() {
         return cy.get('.shopping_cart_link');
     }

--- a/cypress/pageobjects/ProductDetailsPage.js
+++ b/cypress/pageobjects/ProductDetailsPage.js
@@ -1,0 +1,49 @@
+class ProductDetailsPage {
+
+    // Properties
+
+    get page() {
+        return cy.get('#inventory_item_container');
+    }
+
+    get name() {
+        return cy.get('.inventory_details_name');
+    }
+
+    get description() {
+        return cy.get('.inventory_details_desc')
+    }
+
+    get price() {
+        return cy.get('.inventory_details_price')
+    }
+
+    get backButton() {
+        return cy.dataTest('back-to-products');
+        //return cy.get('.inventory_details_back_button');
+    }
+
+    get addButton() {
+        return cy.get('.btn_primary.btn_inventory')
+    }
+
+    get removeButton() {
+        return cy.get('.btn_secondary.btn_inventory')
+    }
+
+    // Methods
+
+    addToCart() {
+        this.addButton.click();
+    }
+
+    removeFromCart() {
+        this.removeButton.click();
+    }
+
+    goBack() {
+        this.backButton.click();
+    }
+}
+
+export default new ProductDetailsPage();

--- a/cypress/pageobjects/ProductsPage.js
+++ b/cypress/pageobjects/ProductsPage.js
@@ -1,5 +1,7 @@
 class ProductsPage {
 
+    // Properties
+
     isOnPage() {
         return cy.get('#inventory_container').eq(0)
     }
@@ -20,13 +22,14 @@ class ProductsPage {
         return cy.get('.btn_secondary.btn_inventory');
     }
 
-    //
+    // Methods
+
     openProductDetails(productName) {
         this.productList.contains(productName).click();
     }
 
     addToCart(productName) {
-        cy.log('Product name = ' + productName);
+        cy.log('Product name: ' + productName);
 
         // This works
         //cy.get('.inventory_item:contains("Sauce Labs Backpack") .btn_inventory').click();
@@ -52,7 +55,7 @@ class ProductsPage {
     }
 
     removeFromCart(productName) {
-        cy.log('Product name = ' + productName);
+        cy.log('Product name: ' + productName);
         cy.get('.inventory_item:contains("' + productName + '") .btn_secondary.btn_inventory').click();
     }
 }


### PR DESCRIPTION
Add tests and page objects for the products overview page

Specifically the following:
- add products over tests
- add header page object (just enough for this PR)
- add cart summary page object (just enough for this PR)