### PR TITLE
Updated the loginPage object and associated tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ build/Release
 node_modules
 cypress/videos
 cypress/screenshots
+cypress/downloads
 js/*.js
 
 # Apple macOS custom folder attributes

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -3,6 +3,7 @@ const { defineConfig } = require('cypress')
 module.exports = defineConfig({
   e2e: {
     // Configure your E2E tests here
+    baseUrl: 'https://www.saucedemo.com',
     specPattern: "cypress/e2e/**/*.{cy,spec}.{js,ts}"
   },
 })

--- a/cypress/e2e/checkout.info.cy.js
+++ b/cypress/e2e/checkout.info.cy.js
@@ -9,7 +9,6 @@ import CheckoutSummaryPage from "../pageobjects/CheckoutSummaryPage";
 
 describe('Checkout information', () => {
     beforeEach(() => {
-        cy.visit("https://www.saucedemo.com")
         LoginPage.logIn("standard_user", "secret_sauce")
         ProductsPage.page.should('be.visible');
 

--- a/cypress/e2e/login.cy.js
+++ b/cypress/e2e/login.cy.js
@@ -6,22 +6,29 @@ import ProductsPage from "../pageobjects/ProductsPage";
 describe ('LoginPage', () => {
 
     beforeEach(() => {
-        cy.visit("https://www.saucedemo.com")
+        cy.visit('/');
     })
 
     it('should be able to test loading of login page', () => {
         LoginPage.page.should('be.visible');
-    });
+        LoginPage.username.should('be.visible');
+        LoginPage.password.should('be.visible');
+        LoginPage.loginButton.should('be.visible');
+    })
 
-    it.only('should be able to login with a standard user', () => {
-        LoginPage.logIn("standard_user", "secret_sauce")
-        ProductsPage.page.should('be.visible');
-    });
+    context('given valid user credentials', () => {
+        it.only('redirects to products page', () => {
+            LoginPage.logIn("standard_user", "secret_sauce")
+            ProductsPage.page.should('be.visible');
+        })
+    })
 
-    it('should not be able to login with a locked user', () => {
-        LoginPage.logIn("locked_out_user", "secret_sauce");
-        LoginPage.errorMessage.should('have.text','Epic sadface: Sorry, this user has been locked out.');
-    });
+    context('given INVALID user credentials', () => {
+        it('shows login error', () => {
+            LoginPage.logIn("locked_out_user", "secret_sauce");
+            LoginPage.errorMessage.should('have.text','Epic sadface: Sorry, this user has been locked out.');
+        })
+    })
 
     // TODO add additional scenarios - invalid username, password, etc
 });

--- a/cypress/e2e/menu.cy.js
+++ b/cypress/e2e/menu.cy.js
@@ -6,7 +6,6 @@ import ProductsPage from "../pageobjects/ProductsPage";
 
 describe('Menu', () => {
     beforeEach(() => {
-        cy.visit("https://www.saucedemo.com")
         LoginPage.logIn("standard_user", "secret_sauce")
         ProductsPage.page.should('be.visible');
         MenuPage.open();

--- a/cypress/e2e/product.details.cy.js
+++ b/cypress/e2e/product.details.cy.js
@@ -7,7 +7,6 @@ import HeaderPage from "../pageobjects/HeaderPage";
 
 describe('Product details page', () => {
     beforeEach(() => {
-        cy.visit("https://www.saucedemo.com")
         LoginPage.logIn("standard_user", "secret_sauce")
         ProductsPage.page.should('be.visible');
     })

--- a/cypress/e2e/product.overview.cy.js
+++ b/cypress/e2e/product.overview.cy.js
@@ -8,7 +8,6 @@ import ShoppingCartPage from "../pageobjects/ShoppingCartPage";
 
 describe('Product overview page', () => {
     beforeEach(() => {
-        cy.visit("https://www.saucedemo.com")
         LoginPage.logIn("standard_user", "secret_sauce")
         ProductsPage.page.should('be.visible');
     })

--- a/cypress/e2e/product.sort.cy.js
+++ b/cypress/e2e/product.sort.cy.js
@@ -5,7 +5,6 @@ import ProductsPage from "../pageobjects/ProductsPage";
 
 describe('Product page sorting', () => {
     beforeEach(() => {
-        cy.visit("https://www.saucedemo.com");
         LoginPage.logIn("standard_user", "secret_sauce");
         ProductsPage.page.should('be.visible');
     })

--- a/cypress/e2e/shopping.cart.cy.js
+++ b/cypress/e2e/shopping.cart.cy.js
@@ -8,7 +8,6 @@ import CheckoutInfoPage from "../pageobjects/CheckoutInfoPage";
 
 describe('Shopping cart summary', () => {
     beforeEach(() => {
-        cy.visit("https://www.saucedemo.com")
         LoginPage.logIn("standard_user", "secret_sauce")
         ProductsPage.page.should('be.visible');
     })

--- a/cypress/pageobjects/LoginPage.js
+++ b/cypress/pageobjects/LoginPage.js
@@ -1,4 +1,5 @@
 class LoginPage {
+
     get page() {
         return cy.get('#login_button_container');
     }
@@ -26,6 +27,14 @@ class LoginPage {
      * @param {string} password
      */
     logIn(username, password) {
+        // The demo site from Sauce Labs has a problem with the way Service Workers have been
+        // configured. It sometimes causes the 'load' event not to happen. I tried various ways
+        // to resolve the issue, but the solution was to simply disable the service worker by
+        // stubbing the API call.
+        cy.intercept('/service-worker.js', {
+            body: undefined
+        })
+        cy.visit('/');
 
         if (username) {
             this.username.type(username);


### PR DESCRIPTION
Updated the login page object to handle the service worker issue.

- login function now stubs the service worker
- login function now calls cy.visit('/'), since access to every page MUST go via the login
- updated all tests and removed the cy.visit() call, since all tests call LoginPage.login()
