### PR TITLE
Add command to set contents of shopping cart

### DIFF
--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -15,4 +15,15 @@ declare namespace Cypress {
          */
         dataTest(value: string) : Chainable<any>;
     }
+
+    interface Chainable<Subject = any> {
+        /**
+         * Custom command to directly set the contents of the shopping
+         * cart in the web browsers LocalStorage. Takes an array of integers.
+         *
+         * @param newContents - array of product IDs
+         * @example cy.setCartContents([PRODUCTS.BOLT_TSHIRT, PRODUCTS.BACKPACK])
+         */
+        setCartContents(newContents: any): void
+    }
 }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -37,3 +37,8 @@ Cypress.Commands.add('dataTest', {prevSubject: 'optional'}, (subject, value) => 
         return cy.get(`[data-test=${value}]`);
     }
 })
+
+Cypress.Commands.add('setCartContents', (newContents) => {
+    cy.log('Product IDs: ' + newContents);
+    window.localStorage.setItem("cart-contents", JSON.stringify(newContents));
+})


### PR DESCRIPTION
Add command/method to directly set the contents of the shopping cart

Take an array of product IDs (see PRODUCTS constant)

